### PR TITLE
Change in the docker-compose.yml of the LEVEL_TYPE variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       FORGEVERSION: "36.2.39"
       MEMORY: "16G"
       OPS: "BideoGemu"
-      LEVEL_TYPE: skyblockbuilder\:custom_skyblock
+      LEVEL_TYPE: skyblockbuilder:custom_skyblock
       ALLOW_FLIGHT: "true"
       MOTD: "BlackStone Block On Docker"
     tty: true


### PR DESCRIPTION
Change in the docker-compose.yml of the variable `LEVEL_TYPE` to correct the following error leading to a crash of the server:
```
minecraft  |  [main/FATAL] [minecraft/Main]: Failed to start the minecraft server
minecraft  |  net.minecraft.util.ResourceLocationException: Non [a-z0-9_.-] character in namespace of location: skyblockbuilder\:custom_skyblock
```
